### PR TITLE
decode unicode args for python 2

### DIFF
--- a/click/core.py
+++ b/click/core.py
@@ -636,7 +636,7 @@ class BaseCommand(object):
         raise NotImplementedError('Base commands are not invokable by default')
 
     def main(self, args=None, prog_name=None, complete_var=None,
-             standalone_mode=True, **extra):
+             standalone_mode=True, encoding='utf-8', **extra):
         """This is the way to invoke a script with all the bells and
         whistles as a command line application.  This will always terminate
         the application after a call.  If this is not wanted, ``SystemExit``
@@ -666,6 +666,8 @@ class BaseCommand(object):
                                 propagated to the caller and the return
                                 value of this function is the return value
                                 of :meth:`invoke`.
+        :param encoding: if using python 2, decode arguments using this encoding. 
+                         defaults to 'utf-8'.
         :param extra: extra keyword arguments are forwarded to the context
                       constructor.  See :class:`Context` for more information.
         """
@@ -676,11 +678,16 @@ class BaseCommand(object):
             _verify_python3_env()
         else:
             _check_for_unicode_literals()
-
-        if args is None:
-            args = get_os_args()
+        if PY2:
+            if args is None:
+                args = [arg.decode(encoding) for arg in get_os_args()]
+            else:
+                args = [arg.decode(encoding) for arg in args]
         else:
-            args = list(args)
+            if args is None:
+                args = get_os_args()
+            else:
+                args = list(args)
 
         if prog_name is None:
             prog_name = make_str(os.path.basename(


### PR DESCRIPTION
When using python 2, utf-8 encoded characters in args will throw a UnicodeDecodeError (tries to decode as 'ascii'). This small change adds a keyword argument to main(), 'encoding', which corresponds to the encoding to be used. It defaults to 'utf-8'.